### PR TITLE
Adds default plugins and updates readme information

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,9 @@ Vagrant requires:
 * Vagrant to be installed - http://docs.vagrantup.com/v2/installation/
 * VirtualBox to be installed - https://www.virtualbox.org/wiki/Downloads
 
+WordPress beta testing
+------------------
+To enable testing with beta versions or release candidates of WordPress, the WordPress beta tester plugin is installed in the Vagrant test box. 
 
 Grunt Integration
 ------------------

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -154,6 +154,20 @@ fi
 	--post_status=publish \
 	--allow-root
 
+# Add/Remove plugins then update everything that is installed.
+/var/www/wordpress/wp-cli plugin uninstall hello \
+	--path=/var/www/wordpress \
+	--allow-root
+
+/var/www/wordpress/wp-cli plugin install "WordPress Beta Tester" \
+	--path=/var/www/wordpress \
+	--allow-root
+
+/var/www/wordpress/wp-cli plugin update \
+	--path=/var/www/wordpress \
+	--allow-root \
+	--all
+
 ## Set excessively liberal permissions on all of WordPress since we are testing.
 chmod -R 777 /var/www/wordpress
 chown www-data.www-data /var/www/wordpress -R


### PR DESCRIPTION
- The WordPress Beta Tester plugin is now installed by default on the Vagrant test box.
- Readme information is updated to communicate the addition of the Beta Tester plugin.